### PR TITLE
Redirect http to https on Heroku

### DIFF
--- a/client/server.js
+++ b/client/server.js
@@ -3,6 +3,13 @@ const path = require('path');
 const port = process.env.PORT || 3000;
 const app = express();
 
+// redirect http to https on Heroku
+app.use(function (req, res, next) {
+  if (process.env.NODE_ENV !== 'production') return next();
+  if (req.headers['x-forwarded-proto'] === 'https') return next();
+  return res.redirect(301, `https://${req.hostname}${req.originalUrl}`);
+});
+
 app.use(express.static(path.join(__dirname, 'build')));
 
 app.get(/.*/, function (req, res) {


### PR DESCRIPTION
👋 @LGG233 

**Problem Solved:** `http` and `https` versions of our Heroku site are considered _different_ by internet browsers. As a result, they maintain separate local storages. This creates a poor user experience if a customer logs in using `https` and then inadvertantly jumps over to `http` only to find they are no longer logged in!

This one was rather simple after some crafty Googling. Heroku attaches a request header `X-Fowarded-Proto` which represents the protocol used:`http` or `https`. ([source](https://devcenter.heroku.com/articles/http-routing#heroku-headers)) This should not impact local development since we only use the express server for Heroku. Credit to [node-heroku-ssl-redirect](https://github.com/nodenica/node-heroku-ssl-redirect/blob/master/index.js) for 90% of this code. 😈 I stand on the shoulders of giants to reach the cookie jar.

I deployed and verified. It works!